### PR TITLE
[BUGFIX] Fix duplicate banners on stylesheets during build

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -27,7 +27,7 @@ module.exports = function(grunt) {
 			},
 			sass: {
 				files: '<%= sourcePath %>/<%= assetDir %>/scss/**/*.scss',
-				tasks: ['compass:dist', 'usebanner', 'copy:assets']
+				tasks: ['compass:dist', 'copy:assets', 'usebanner']
 			},
 			html: {
 				files: '<%= sourcePath %>/<%= templateDir %>/**/*.hbs',
@@ -87,7 +87,7 @@ module.exports = function(grunt) {
 					linebreak: true
 				},
 				files: {
-					src: [ '<%= sourcePath %>/<%= assetDir %>/css/screen.css' ]
+					src: [ '<%= distPath %>/<%= assetDir %>/css/*.css' ]
 				}
 			}
 		},
@@ -146,6 +146,6 @@ module.exports = function(grunt) {
 	grunt.loadNpmTasks('grunt-smushit');
 	grunt.loadNpmTasks('assemble');
 
-	grunt.registerTask('default', ['uglify', 'compass', 'usebanner', 'assemble', 'prettify:dist', 'copy:assets']);
+	grunt.registerTask('default', ['uglify', 'compass', 'assemble', 'prettify:dist', 'copy:assets', 'usebanner']);
 
 };

--- a/src/assets/css/screen.css
+++ b/src/assets/css/screen.css
@@ -1,9 +1,3 @@
-/** 
- * Automatically Generated - DO NOT EDIT 
- * KPS3 / v1.0.0 / 2014-06-06 
- */ 
-
-
 /*! normalize.css v2.1.3 | MIT License | git.io/normalize */
 /* ========================================================================== HTML5 display definitions ========================================================================== */
 /** Correct `block` display not defined in IE 8/9. */
@@ -135,7 +129,7 @@ meta.foundation-mq-large { font-family: "only screen and (min-width:1440px)"; wi
 
 html, body { font-size: 16px; }
 
-body { background: white; color: #222222; padding: 0; margin: 0; font-family: "Helvetica Neue", "Helvetica", Helvetica, Arial, sans-serif; font-weight: normal; font-style: normal; line-height: 1; position: relative; cursor: default; }
+body { background: #fff; color: #222; padding: 0; margin: 0; font-family: "Helvetica Neue", "Helvetica", Helvetica, Arial, sans-serif; font-weight: normal; font-style: normal; line-height: 1; position: relative; cursor: default; }
 
 a:hover { cursor: pointer; }
 


### PR DESCRIPTION
This PR fixes duplicate banners being appended to stylesheets in the `dist` directory during build.
