### PR TITLE
[INTERNAL] Add npm scripts for start and build

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "postinstall": "grunt"
+    "postinstall": "grunt",
+    "start": "grunt watch",
+    "build": "grunt"
   },
   "devDependencies": {
     "grunt": "~0.4.2",


### PR DESCRIPTION
This PR allows you to use `npm start` instead of `grunt watch` and `npm run build` instead of `grunt`.

This doesn't change existing functionality. You can still use `grunt` and `grunt watch`.