### PR TITLE
[BUGFIX] Remove grunt from getting started dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ More details on how it works and the backstory can be found at: http://kps3.com/
 
 ## Getting Started
 
-Make sure you have [Yarn](https://yarnpkg.com/) and [Grunt](http://gruntjs.com/) installed.
+Make sure you have [Yarn](https://yarnpkg.com/) installed.
 
 ```
 $ git clone https://github.com/kps3/kps3-boilerplate.git


### PR DESCRIPTION
Grunt isn't required globally if you're using package.json scripts through yarn/npm commands.