### PR TITLE
[BUGFIX] Fix global script tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "KPS3",
   "description": "",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "private": true,
   "scripts": {
     "postinstall": "grunt",

--- a/src/templates/layouts/default.hbs
+++ b/src/templates/layouts/default.hbs
@@ -21,6 +21,6 @@
     <!-- Scripts -->
     <script src="{{assets}}/scripts/lib/jquery.min.js"></script>
     <script src="{{assets}}/scripts/vendor/min/plugins.js"></script>
-    <script src="{{assets}}/scripts/min/global.js"></script>
+    <script src="{{assets}}/scripts/min/main.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Renamed `global.js` to `main.js` but forgot to update the default layout to reflect this.